### PR TITLE
Clarify wording for `did:key` principals

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ type UCAN struct {
 
 ## 2.1 Principal
 
-Principals MUST use the [bytesprefix](https://ipld.io/docs/schemas/using/authoring-guide/#bytesprefix-unions-for-bytes) representation of [DID](https://www.w3.org/TR/did-core/)s. The primary [`did:key` method](https://w3c-ccg.github.io/did-method-key/) MUST use key-specific representation, such as `0xe7` and `0x1200`. Additional DID methods MAY use the open `DID` representation `0x0d1d`.
+Principals MUST use the [bytesprefix](https://ipld.io/docs/schemas/using/authoring-guide/#bytesprefix-unions-for-bytes) representation of [DID](https://www.w3.org/TR/did-core/)s. The primary [`did:key` method](https://w3c-ccg.github.io/did-method-key/) MUST use the relevant key-specific representation, such as `0xe7` and `0x1200`. Additional DID methods MAY use the extensible `DID` representation `0x0d1d`.
 
 ``` ipldsch
 type Principal union {

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ type UCAN struct {
 
 ## 2.1 Principal
 
-Principals MUST use [bytesprefix](https://ipld.io/docs/schemas/using/authoring-guide/#bytesprefix-unions-for-bytes) representation of [DID](https://www.w3.org/TR/did-core/)s. Primary [`did:key` method](https://w3c-ccg.github.io/did-method-key/) MUST use (more compact) key specific variant representation. Additional DID methods MAY use `DID` variant representation.
+Principals MUST use the [bytesprefix](https://ipld.io/docs/schemas/using/authoring-guide/#bytesprefix-unions-for-bytes) representation of [DID](https://www.w3.org/TR/did-core/)s. The primary [`did:key` method](https://w3c-ccg.github.io/did-method-key/) MUST use key-specific representation, such as `0xe7` and `0x1200`. Additional DID methods MAY use the open `DID` representation `0x0d1d`.
 
 ``` ipldsch
 type Principal union {


### PR DESCRIPTION
[Reported by @cdata](https://discord.com/channels/1002414684579827792/1009530220245700748/1023419026279497848)

The existing wording of "variant" reads ambiguously. I'm 99.9% sure that we mean "variant" in the union sense.