### PR TITLE
v0.2: update to UCAN 0.10 & reference derivative specs

### DIFF
--- a/.github/workflows/words-to-ignore.txt
+++ b/.github/workflows/words-to-ignore.txt
@@ -39,6 +39,7 @@ expede
 inlined
 interpretable
 multicodec
+multidid
 multiformat
 multihash
 namespaced

--- a/README.md
+++ b/README.md
@@ -37,23 +37,21 @@ Unlike a JWT, the IPLD encoding of UCAN does not require separate header, claims
 
 ```ipldsch
 type UCAN struct {
-  v String
+  v            String
 
-  iss Principal
-  aud Principal
-  s Signature
+  iss          Principal
+  aud          Principal
 
-  cap Capabilities
+  cap          Capabilities
+  prf          [&UCAN]
 
-  -- All proofs are links, however you could still inline proof
-  -- by using CID with identity hashing algorithm
-  prf [&UCAN]
-
-  fct [Fact]
   nnc optional String
+  fct          [Fact]
 
   nbf optional Int
   exp          Int
+
+  s            Signature
 } representation map {
   field fct default []
   field prf default []
@@ -66,7 +64,7 @@ Principals MUST use the [multidid] representation of [DID]s.
 
 ## 2.2 Capabilities
 
-Capabilities are a map ____________.
+Capabilities UST be represented as a nested map from resources to abilities to non-normative caveats.
 
 ``` ipldsch
 type Capabilities = { Resource : { Ability: [ Caveats ] } }
@@ -114,8 +112,7 @@ As of UCAN 0.9, all proofs MUST be given as links (CIDs). Note that UCANs MAY be
 
 ## 2.5 Signature
 
-The signature MUST be computed by first encoding it as a [canonical JWT], and then signed with the issuer's private key. Signatures MUST be encoded as the _varsig_ multiformat representation `<varint sig_alg_code><vairint sig_size><bytes sig_output>`. <!---------------- FIXME      _Varsig_ multiformat codes SHOULD be [registered multicodec codes](https://github.com/multiformats/multicodec). Unregistered signature types MAY be added via the `NonStandardSignature` prefix 
-  -->
+The signature MUST be computed by first encoding it as a [canonical JWT], and then signed with the issuer's private key. Signatures MUST be encoded as the [varsig] multiformat representation `<varint sig_alg_code><vairint sig_size><bytes sig_output>`.
 
 # 3 Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Principals MUST use the [multidid] representation of [DID]s.
 Capabilities UST be represented as a nested map from resources to abilities to non-normative caveats.
 
 ``` ipldsch
-type Capabilities = { Resource : { Ability: [ Caveats ] } }
+type Capabilities = { Resource : { Ability: [ CaveatsMap ] } }
 ```
 
 ### 2.2.1 Resource
@@ -91,7 +91,7 @@ type Ability = String
 The inclusion of caveats is OPTIONAL. When present, this map MUST contain any additional domain specific details and/or restrictions of the capability. 
 
 ``` ipldsch
-type Caveats = { String: Any }
+type CaveatsMap = { String: Any }
 ```
 
 ## 2.3 Fact

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Principals MUST use the [multidid] representation of [DID]s.
 
 ## 2.2 Capabilities
 
-Capabilities UST be represented as a nested map from resources to abilities to non-normative caveats.
+Capabilities MUST be represented as a nested map from resources to abilities to non-normative caveats.
 
 ``` ipldsch
 type Capabilities = { Resource : { Ability: [ CaveatsMap ] } }

--- a/README.md
+++ b/README.md
@@ -1,26 +1,35 @@
-# UCAN IPLD Schema v0.1.0
+# UCAN IPLD Schema v0.2.0
 
 ## Editors
 
-* [Irakli Gozalishvili](https://github.com/Gozala), DAG House
+* [Irakli Gozalishvili], [DAG House]
 
 ## Authors
 
-* [Hugo Dias](https://github.com/hugomrdias), DAG House
-* [Irakli Gozalishvili](https://github.com/Gozala), DAG House
-* [Brooklyn Zelenka](https://github.com/expede), [Fission](https://fission.codes)
+* [Hugo Dias], [DAG House]
+* [Irakli Gozalishvili], [DAG House]
+* [Brooklyn Zelenka], [Fission Codes]
+
+## Dependencies
+
+* [IPLD]
+* [UCAN Canonicalization]
+* [UCAN Delegation]
+* [multicodec]
+* [multidid]
+* [varsig]
 
 ## Language
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC2119](https://datatracker.ietf.org/doc/html/rfc2119).
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC2119].
 
 # 0 Abstract
 
-[Interplanetary Linked Data (IPLD)](https://ipld.io/) is a consistent, highly general data model for content addressed linked data forming any DAG. This data model provides a convenient pivot between many serializations of the same information. Being a chained token model, UCANs can be very naturally expressed via IPLD. However, JWTs are not fully deterministic due to whitespace and key ordering. This specification defines an IPLD Schema for UCAN, and a canonical JWT serialization for compatibility with all other clients.
+[Interplanetary Linked Data (IPLD)][IPLD] is a consistent, highly general data model for content addressed linked data forming any DAG. This data model provides a convenient pivot between many serializations of the same information. Being a chained token model, UCANs can be very naturally expressed via IPLD. However, JWTs are not fully deterministic due to whitespace and key ordering. This specification defines an IPLD Schema for UCAN, and a canonical JWT serialization for compatibility with all other clients.
 
 # 1 Motivation
 
-The [core UCAN specification](https://github.com/ucan-wg/spec) is defined as a JWT to make it easily adoptable with existing tools, and as a common format for all implementations. There are many cases where different encodings are preferred for reasons such as compactness, machine-efficient formats, and so on. This specification outlines a format based on IPLD that can be deterministically encoded and decoded between many serialization formats, while still being able to encode as JWT for compatibility.
+The [UCAN Delegation] specification is defined as a JWT to make it easily adoptable with existing tools, and as a common format for all implementations. There are many cases where different encodings are preferred for reasons such as compactness, machine-efficient formats, and so on. This specification outlines a format based on IPLD that can be deterministically encoded and decoded between many serialization formats, while still being able to encode as JWT for compatibility.
 
 # 2 IPLD Schema
 
@@ -34,15 +43,17 @@ type UCAN struct {
   aud Principal
   s Signature
 
-  att [Capability]
+  cap Capabilities
+
   -- All proofs are links, however you could still inline proof
   -- by using CID with identity hashing algorithm
   prf [&UCAN]
-  exp Int
 
   fct [Fact]
   nnc optional String
+
   nbf optional Int
+  exp          Int
 } representation map {
   field fct default []
   field prf default []
@@ -51,43 +62,19 @@ type UCAN struct {
 
 ## 2.1 Principal
 
-Principals MUST use the [bytesprefix](https://ipld.io/docs/schemas/using/authoring-guide/#bytesprefix-unions-for-bytes) representation of [DID](https://www.w3.org/TR/did-core/)s. The primary [`did:key` method](https://w3c-ccg.github.io/did-method-key/) MUST use the relevant key-specific representation, such as `0xe7` and `0x1200`. Additional DID methods MAY use the extensible `DID` representation `0x0d1d`.
+Principals MUST use the [multidid] representation of [DID]s.
+
+## 2.2 Capabilities
+
+Capabilities are a map ____________.
 
 ``` ipldsch
-type Principal union {
-  -- This specification defines principals in terms of `did:key`s (multicodec
-  -- identifiers for the public key type followed by the raw bytes of the key).
-  -- We represent those as raw public key bytes prefixed with public key 
-  -- multiformat code.
-  | secp256k1  "0xe7"
-  | BLS12381G1 "0xea"
-  | BLS12381G2 "0xeb"
-  | Ed25519    "0xed"
-  | P256       "0x1200"
-  | P384       "0x1201"
-  | P512       "0x1202"
-  | RSA        "0x1205"
-  
-  -- To accomodate additional DID methods we represent those as UTF8 encoding
-  -- of the DID omitting `did:` prefix itself. E.g. `did:dns:ucan.xyz` can be
-  -- represented as [0x0d1d, ...new TextEncoder().encode('dns:ucan.xyz')] bytes.
-  | DID "0x0d1d"
-} representation bytesprefix
-```
-
-## 2.2 Capability
-
-``` ipldsch
-type Capability struct {
-  with Resource
-  can Ability
-  nb optional NonNormativeFields
-}
+type Capabilities = { Resource : { Ability: [ Caveats ] } }
 ```
 
 ### 2.2.1 Resource
 
-The resource pointer MUST be formatted as a [URI](https://www.rfc-editor.org/rfc/rfc3986).
+The resource pointer MUST be formatted as a [URI].
 
 ``` ipldsch
 type Resource = String
@@ -101,12 +88,12 @@ Abilities MUST be lowercase, and MUST be namespaced with `/` delimeters. Abiliti
 type Ability = String
 ```
 
-### 2.2.3 `nb` Non-Normative Fields
+### 2.2.3 Caveats
 
-The `nb` capability field is OPTIONAL. When present, it MUST contain any additional domain specific details and/or restrictions of the capability. 
+The inclusion of caveats is OPTIONAL. When present, this map MUST contain any additional domain specific details and/or restrictions of the capability. 
 
 ``` ipldsch
-type NonNormativeFields = { String: Any }
+type Caveats = { String: Any }
 ```
 
 ## 2.3 Fact
@@ -119,7 +106,7 @@ type Fact { String: Any }
 
 ## 2.4 Proof
 
-As of UCAN 0.9, all proofs MUST be given as links (CIDs). Note that UCANs MAY be inlined via the [identity multihash (`0x00`)](https://github.com/multiformats/multicodec/blob/master/table.csv#L2) CID.
+As of UCAN 0.9, all proofs MUST be given as links (CIDs). Note that UCANs MAY be inlined via the [identity multihash](https://github.com/multiformats/multicodec/blob/master/table.csv#L2) (`0x00`) CID.
 
 ``` ipldsch
 &UCAN
@@ -127,54 +114,33 @@ As of UCAN 0.9, all proofs MUST be given as links (CIDs). Note that UCANs MAY be
 
 ## 2.5 Signature
 
-The signature MUST be computed by first encoding it as a [canonical JWT](#3-jwt-canonicalization), and then signed with the issuer's private key. Signatures MUST be encoded as the _varsig_ multiformat representation `<varint sig_alg_code><vairint sig_size><bytes sig_output>`. _Varsig_ multiformat codes SHOULD be [registered multicodec codes](https://github.com/multiformats/multicodec). Unregistered signature types MAY be added via the `NonStandardSignature` prefix.
+The signature MUST be computed by first encoding it as a [canonical JWT], and then signed with the issuer's private key. Signatures MUST be encoded as the _varsig_ multiformat representation `<varint sig_alg_code><vairint sig_size><bytes sig_output>`. <!---------------- FIXME      _Varsig_ multiformat codes SHOULD be [registered multicodec codes](https://github.com/multiformats/multicodec). Unregistered signature types MAY be added via the `NonStandardSignature` prefix 
+  -->
 
-``` ipldsch
-type Signature union {
-  -- Algorithms here are expected to be valid "varsig" multiformat codes.
-  | NonStandard "0xd000"
-  | ES256K      "0xd0e7" -- secp256k1
-  | BLS12381G1  "0xd0ea" -- NB: G1 is a signature for BLS-12381 G2
-  | BLS12381G2  "0xd0eb" -- NB: G2 is a signature for BLS-12381 G1
-  | EdDSA       "0xd0ed"
-  | ES256       "0xd01200"
-  | ES384       "0xd01201"
-  | ES512       "0xd01202"
-  | RS256       "0xd01205"
-  | EIP191      "0xd191"
-} representation bytesprefix
-```
-
-### 2.5.1 Nonstandard Signatures
-
-Nonstandard signature algorithms MAY be used, but are NOT RECOMMENDED as they are not widely interoperable.
-
-The `0xd000` prefix MUST be used if a nonstandard signature is used. Nonstandard signatures MUST be additionally prefixed with a varint of the signature length, and the UTF-8 UCAN `alg` field appended afterwards.
-
-```
-<varint 0xd000><varint sig_size><bytes sig><utf8 alg>`
-```
-
-# 3 JWT Canonicalization
-
-Per the core UCAN spec, all implementations MUST support JWT encoding. This provides a common representation that all implementations can understand. JWT canonicalization allows for an IPLD UCAN to be expressed as a JWT, retain the JWT signature scheme, and so on for compatibility, while retaining the ability to translate into other formats for storage or transmission among IPLD-enabled peers.
-
-To canonicalize an IPLD UCAN to JWT, the JSON segments MUST fulfill the following requirements:
-
-1. All `can` fields MUST be lowercase
-2. All unused optional fields (such as `fct`) that are empty MUST be omitted
-3. [`dag-json`](https://ipld.io/specs/codecs/dag-json/spec/) encoding MUST be used
-4. The resulting JWT MUST be [base64url](https://datatracker.ietf.org/doc/html/rfc4648#section-5) encoded per [RFC 7519]
-5. All segments MUST be joined with `.`s, per [RFC 7519](https://www.rfc-editor.org/rfc/rfc7519)
-
-UCAN canonicalization is signalled by CID. If no canonicalization is used, the CID MUST use the [raw multicodec](https://github.com/multiformats/multicodec/blob/master/table.csv#L39). Canonicalized UCANs that wish to signal this encoding MUST use [any other CID codec](https://github.com/multiformats/multicodec/blob/master/table.csv), including but not limited to `dag-json` and `dag-cbor`.
-
-## 3.1 Non-IPLD Validator CID Handling
-
-Validators that have not implemented this specification MUST be provided JWT-encoded UCANs. These validators will be unable to validate the CID in the proofs field. This is not strictly a problem in a semi-trusted scenario, as UCAN only depends on the existence (not the specific CID) of a valid proof for the capabilities being claimed. The security risk is for a malicious peer to provide very long but ultimately invalid proof chains as a denial-of-service vector. This is the case for any validator that does not check the CID hash upon receipt.
-
-# 4 Acknowledgments
+# 3 Acknowledgments
 
 Many thanks to [Joel Thorstensson](https://github.com/oed) and [Sergey Ukustov](https://github.com/ukstv) at [3Box Labs](https://3boxlabs.com/) for their feedback on the encoding, and considerations on how it would interact with [SIWE](https://eips.ethereum.org/EIPS/eip-4361).
 
 Thanks to [Philipp Krüger](https://github.com/matheus23) for his feedback on canonicalization signalling.
+
+<!-- Links -->
+
+[Brooklyn Zelenka]: https://github.com/expede
+[DAG House]: https://dag.house
+[DID]: https://www.w3.org/TR/did-core/
+[Fission Codes]: https://fission.codes
+[Hugo Dias]: https://github.com/hugomrdias
+[IPLD]: https://ipld.io/
+[Irakli Gozalishvili]: https://github.com/Gozala
+[RFC2119]: https://datatracker.ietf.org/doc/html/rfc2119
+[UCAN Canonicalization]: https://github.com/ucan-wg/canonicalization/
+[UCAN Canonicalization]: https://github.com/ucan-wg/canonicalization/ 
+[UCAN Delegation]: https://github.com/ucan-wg/spec
+[URI]: https://www.rfc-editor.org/rfc/rfc3986
+[`dag-json`]: https://ipld.io/specs/codecs/dag-json/spec/
+[`did:key`]: https://w3c-ccg.github.io/did-method-key/
+[bytesprefix]: https://ipld.io/docs/schemas/using/authoring-guide/#bytesprefix-unions-for-bytes
+[identity multihash]: https://github.com/multiformats/multicodec/blob/master/table.csv#L2
+[multicodec]: https://github.com/multiformats/multicodec
+[multidid]: https://github.com/ChainAgnostic/multidid 
+[varsig]: https://github.com/ChainAgnostic/varsig/


### PR DESCRIPTION
[📚 Preview](https://github.com/ucan-wg/ucan-ipld/blob/update-to-ucan-0.10/README.md)

I thought that this would be just updating the capability section to a map, but it turns out that a bunch of this stuff has been broken out into other specs. I guess that's a good thing, but this PR ended up with way more LOC changed.